### PR TITLE
Add check for correct command line arguments

### DIFF
--- a/FinalProject.cpp
+++ b/FinalProject.cpp
@@ -7,6 +7,12 @@ using namespace std;
 
 int main(int argc, char* argv[])
 {
+
+    if (argc != 2) { 
+        cout << "Correct Usage: " << argv[0] << " FileName.txt" << endl;
+        exit(1);
+        
+    }
     MovieTree movietree;
     int ranker=0;
     int counter=0;


### PR DESCRIPTION
This addition adds a check for the correct amount of command line arguments, and reminds the user of correct usage if they use it incorrectly. This fixes #1 
